### PR TITLE
Some more tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       example.com:
         ipv4_address: 10.5.0.3
     ports:
+      - "37778:7778"
       - "38080:8080"
     volumes:
       - ./share:/home/presto

--- a/services/presto/entrypoint.sh
+++ b/services/presto/entrypoint.sh
@@ -56,7 +56,8 @@ if [ ! -f "${JKS_KEYSTORE_FILE}" ]; then
         -keyalg RSA \
         -keystore "${JKS_KEYSTORE_FILE}" \
         -validity 10000 \
-        -dname "cn=Unknown, ou=Unknown, o=Unknown, c=Unknown"\
+        -dname "cn=Unknown, ou=Unknown, o=Unknown, c=Unknown" \
+        -ext "SAN:c=DNS:localhost,IP:127.0.0.1,DNS:presto-kerberos" \
         -storepass "${JKS_KEYSTORE_PASS}"
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -2,4 +2,5 @@
 
 set -euo pipefail
 
-./send-presto-query.sh "SELECT 1"
+SQL=${1:-SELECT 1}
+./send-presto-query.sh "$SQL"


### PR DESCRIPTION
Adding subject alt names to the keystore (so that other machines can address Presto as "presto-kerberos" or from localhost if mapped out to host Docker machine)

Exposing 7778 port to host machine

Adding ability to pass query as argument to test.sh (defaults to "SELECT 1" as before)