### PR TITLE
Update Dockerfile to fix centos EoL

### DIFF
--- a/krb5-centos/kdc-server/Dockerfile
+++ b/krb5-centos/kdc-server/Dockerfile
@@ -8,8 +8,7 @@ FROM centos:8
 WORKDIR /root/
 
 # moving to old repos
-RUN cd /etc/yum.repos.d/ &&  \
-    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # Dev stuff

--- a/krb5-centos/kdc-server/Dockerfile
+++ b/krb5-centos/kdc-server/Dockerfile
@@ -7,6 +7,12 @@ FROM centos:8
 # build environment
 WORKDIR /root/
 
+# moving to old repos
+RUN cd /etc/yum.repos.d/ &&  \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
+    yum update -y
+
 # Dev stuff
 RUN dnf -y install curl wget && dnf clean all
 

--- a/krb5-centos/kdc-server/Dockerfile
+++ b/krb5-centos/kdc-server/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /root/
 # moving to old repos
 RUN cd /etc/yum.repos.d/ &&  \
     sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
-    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* && \
-    yum update -y
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # Dev stuff
 RUN dnf -y install curl wget && dnf clean all

--- a/krb5-centos/machine/Dockerfile
+++ b/krb5-centos/machine/Dockerfile
@@ -7,6 +7,10 @@ FROM centos:8
 # build environment
 WORKDIR /root/
 
+RUN cd /etc/yum.repos.d/ &&  \
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 # Dev stuff
 RUN dnf -y install curl wget && dnf clean all
 

--- a/krb5-centos/machine/Dockerfile
+++ b/krb5-centos/machine/Dockerfile
@@ -7,8 +7,7 @@ FROM centos:8
 # build environment
 WORKDIR /root/
 
-RUN cd /etc/yum.repos.d/ &&  \
-    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && \
     sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
 
 # Dev stuff


### PR DESCRIPTION
Centos 8 went EoL, til there's a replacement you'll need to point to the old repository for packages